### PR TITLE
fix macos ci

### DIFF
--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -11,7 +11,7 @@ env:
 jobs:
   default_features:
     name: Default Features
-    runs-on: mac-latest
+    runs-on: macos-latest
     strategy:
       matrix:
         toolchain:
@@ -28,7 +28,7 @@ jobs:
       - run: cargo test --verbose
   mac_features:
     name: All Mac Features
-    runs-on: mac-latest
+    runs-on: macos-latest
     strategy:
       matrix:
         toolchain:


### PR DESCRIPTION
The name of the Github Action for the Mac workflows was incorrect, meaning that they would never run. This change corrects the errors so that the continuous integration successfully runs.